### PR TITLE
fix(adonis): cli step

### DIFF
--- a/articles/nodejs/adonis/from-scratch.md
+++ b/articles/nodejs/adonis/from-scratch.md
@@ -27,13 +27,13 @@ run.config:
 nanobox run
 
 # install adonis so you can use it to generate your application
-npm install -g adonis
+npm install -g adonis-cli
 
 # cd into the /tmp dir to create an app
 cd /tmp
 
 # generate the adonis app
-adonis new myapp
+adonis new myapp --npm
 
 # copy the generated app into the project
 cp -ar ./myapp/. /app


### PR DESCRIPTION
Adonis-CLI is called `adonis-cli` and with the new version we need to specify that we want to use `npm` to install deps.