### PR TITLE
Revert "fix(adonis): cli step"

### DIFF
--- a/articles/nodejs/adonis/from-scratch.md
+++ b/articles/nodejs/adonis/from-scratch.md
@@ -27,13 +27,13 @@ run.config:
 nanobox run
 
 # install adonis so you can use it to generate your application
-npm install -g adonis-cli
+npm install -g adonis
 
 # cd into the /tmp dir to create an app
 cd /tmp
 
 # generate the adonis app
-adonis new myapp --npm
+adonis new myapp
 
 # copy the generated app into the project
 cp -ar ./myapp/. /app


### PR DESCRIPTION
I'm actually going to revert this change.

After merging I wanted to ensure that Adonis officially recommended using `npm` over `yarn` but it looks like they've recently [updated their documentation to include `yarn`](https://adonisjs.com/docs/3.2/installation#_creating_new_project) as an option.

We'll move forward with `yarn` as we've found it to be more performant.