### PR TITLE
Fix typos and DoneJS URL

### DIFF
--- a/app/jade/framework-overview/left-map.jade
+++ b/app/jade/framework-overview/left-map.jade
@@ -1,5 +1,7 @@
+- var a = "aeiou".indexOf(informalName.charAt(0).toLowerCase()) >= 0 ? "an" : "a"
+
 .map
-  .description Nanobox builds an environment and launches the components a #{informalName} app needs to run
+  .description Nanobox builds an environment and launches the components #{a} #{informalName} app needs to run
   img.shadow-icon(data-src="framework-map")
   .components
     each component in requiredComponents

--- a/app/pages/elixir.jade
+++ b/app/pages/elixir.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/language-landing
 block configParams
   -
     title        = "Create and Deploy Elixir Framework Applications | Nanobox"
-    description  = "Learn how to setup a Elixir framework development environment and configure it to deploy to production."
+    description  = "Learn how to setup an Elixir framework development environment and configure it to deploy to production."
     keywords     = "elixir framework, elixir config, elixir development environment, elixir production apps, elixir apps, deploy elixir, create elixir apps, config elixir apps"
     formalName   = "Elixir"
     informalName = "elixir"

--- a/app/pages/erlang.jade
+++ b/app/pages/erlang.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/language-landing
 block configParams
   -
     title        = "Create and Deploy Erlang Framework Applications | Nanobox"
-    description  = "Learn how to setup a Erlang framework development environment and configure it to deploy to production."
+    description  = "Learn how to setup an Erlang framework development environment and configure it to deploy to production."
     keywords     = "erlang framework, erlang config, erlang development environment, erlang production apps, erlang apps, deploy erlang, create erlang apps, config erlang apps"
     formalName   = "Erlang"
     informalName = "erlang"

--- a/app/pages/errors/404.jade
+++ b/app/pages/errors/404.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/base
 block configParams
   -
     title        = "Guide Not Found | Nanobox"
-    description  = "This guides is still in the works, but check back soon."
+    description  = "This guide is still in the works, but check back soon."
 
 block content
   .error-page.not-found

--- a/app/pages/golang/echo.jade
+++ b/app/pages/golang/echo.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/framework-landing
 block configParams
   -
     title        = "Create and Deploy a Production Echo App | Nanobox"
-    description  = "Learn how to setup a Echo development environment and configure it to deploy to production."
+    description  = "Learn how to setup an Echo development environment and configure it to deploy to production."
     keywords     = "echo, echo framework, golang frameworks, echo config, echo development environment, echo production app, echo app, deploy echo, create echo app, config echo app"
     formalName   = "Echo"
     informalName = "echo"

--- a/app/pages/golang/iris.jade
+++ b/app/pages/golang/iris.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/framework-landing
 block configParams
   -
     title        = "Create and Deploy a Production Iris App | Nanobox"
-    description  = "Learn how to setup a Iris development environment and configure it to deploy to production."
+    description  = "Learn how to setup an Iris development environment and configure it to deploy to production."
     keywords     = "iris, iris framework, golang frameworks, iris config, iris development environment, iris production app, iris app, deploy iris, create iris app, config iris app"
     formalName   = "Iris"
     informalName = "iris"

--- a/app/pages/javascript/angular.jade
+++ b/app/pages/javascript/angular.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/framework-landing
 block configParams
   -
     title        = "Create and Deploy a Production Angular App | Nanobox"
-    description  = "Learn how to setup a Angular development environment and configure it to deploy to production."
+    description  = "Learn how to setup an Angular development environment and configure it to deploy to production."
     keywords     = "angular, angular framework, javascript frameworks, angular config, angular development environment, angular production app, angular app, deploy angular, create angular app, config angular app"
     formalName   = "Angular"
     informalName = "angular"

--- a/app/pages/javascript/ember.jade
+++ b/app/pages/javascript/ember.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/framework-landing
 block configParams
   -
     title        = "Create and Deploy a Production Ember App | Nanobox"
-    description  = "Learn how to setup a Ember development environment and configure it to deploy to production."
+    description  = "Learn how to setup an Ember development environment and configure it to deploy to production."
     keywords     = "ember, ember framework, javascript frameworks, ember config, ember development environment, ember production app, ember app, deploy ember, create ember app, config ember app"
     formalName   = "Ember"
     informalName = "ember"

--- a/app/pages/nodejs/adonis.jade
+++ b/app/pages/nodejs/adonis.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/framework-landing
 block configParams
   -
     title        = "Create and Deploy a Production Adonis App | Nanobox"
-    description  = "Learn how to setup a Adonis development environment and configure it to deploy to production."
+    description  = "Learn how to setup an Adonis development environment and configure it to deploy to production."
     keywords     = "adonis, adonis framework, node js frameworks, adonis config, adonis development environment, adonis production app, adonis app, deploy adonis, create adonis app, config adonis app"
     formalName   = "Adonis"
     informalName = "adonis"

--- a/app/pages/nodejs/express.jade
+++ b/app/pages/nodejs/express.jade
@@ -3,7 +3,7 @@ extends /app/pages/templates/framework-landing
 block configParams
   -
     title        = "Create and Deploy a Production Express App | Nanobox"
-    description  = "Learn how to setup a Express development environment and configure it to deploy to production."
+    description  = "Learn how to setup an Express development environment and configure it to deploy to production."
     keywords     = "express, express framework, node js frameworks, express config, express development environment, express production app, express app, deploy express, create express app, config express app"
     formalName   = "Express"
     informalName = "express"

--- a/articles/frameworks/node.yml
+++ b/articles/frameworks/node.yml
@@ -8,7 +8,7 @@ frameworks:
   - {href: /nodejs/adonis, name: Adonis, icon: adonis, devMode: true}
   - {href: /nodejs/nodal, name: Nodal, icon: nodal, devMode: true}
   - {href: /nodejs/feathers, name: Feathers, icon: feathers, devMode: true}
-  - {href: /nodejs/donejs, name: DoneJS, icon: donejs, devMode: true}
+  - {href: /nodejs/done, name: DoneJS, icon: donejs, devMode: true}
   - {href: /nodejs/koa, name: Koa, icon: koa, devMode: true}
   # - {href: /nodejs/horizon, name: Horizon, icon: horizon, devMode: true}
   # - {href: /nodejs/keystonejs, name: KeystoneJS, icon: keystonejs, devMode: true}


### PR DESCRIPTION
- Fix "a" typos ("a" to "an")
- Add smarter "a" or "an" in left-map description
- Fix DoneJS URL from /nodejs/donejs to /nodejs/done in node frameworks
page (guides.nanobox.io/nodejs)
- Fix misc 404 typo