### PR TITLE
Fix static file paths

### DIFF
--- a/articles/python/flask/configure-flask.md
+++ b/articles/python/flask/configure-flask.md
@@ -54,7 +54,7 @@ http {
 
         # Settings to serve static files
         location ^~ /static/  {
-            root /app/static/;
+            root /app/;
         }
 
         # Serve a static file (ex. favico)


### PR DESCRIPTION
By default, with flask, your files in /static/ include /static/ in the URLs.

So for example, your flask app would link to `/static/file.css`. This documentation, therefor, would have nginx looking in `/static/static/file.css`.

This PR fixes that. I'm pretty sure it's still safe, because while the root directory for serving static content is the app, it limits it to /static URLs. Someone who knows more about Nginx than me might want to double check that, though.