### PR TITLE
Corrected the nginx static files 'root' directive path

### DIFF
--- a/articles/python/django/configure-django.md
+++ b/articles/python/django/configure-django.md
@@ -54,7 +54,7 @@ http {
 
         # Settings to serve static files
         location ^~ /static/  {
-            root /app/static/;
+            root /app/;
         }
 
         # Serve a static file (ex. favico)


### PR DESCRIPTION
Requesting a URL of http://hostname/static/hello.png, with the nginx config's static 'root' directive value set originally as '/app/static/', seems to result in nginx incorrectly looking for '/app/static/static/hello.png' (i.e. nginx appends the URL's path to the root directive's value); resulting in 404.