### PR TITLE
Corrected references to the CLI 'nanobox evar add dry-run' command

### DIFF
--- a/articles/elixir/generic/preview-your-app.md
+++ b/articles/elixir/generic/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://phoenix.preview" target="\_blank">http://phoen
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/elixir/phoenix/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/elixir/phoenix/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/elixir/phoenix/preview-your-app.md
+++ b/articles/elixir/phoenix/preview-your-app.md
@@ -19,7 +19,7 @@ Visit your app at <a href="http://phoenix.preview" target="\_blank">http://phoen
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/elixir/phoenix/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/elixir/phoenix/local-evars) with `nanobox evar add dry-run KEY=VALUE`.
 
 #### Phoenix 1.3 PORT environment variable
 

--- a/articles/golang/beego/preview-your-app.md
+++ b/articles/golang/beego/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://beego.preview" target="\_blank">http://beego.p
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/beego/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/beego/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/golang/echo/preview-your-app.md
+++ b/articles/golang/echo/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://echo.preview" target="\_blank">http://echo.pre
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/echo/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/echo/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/golang/generic/preview-your-app.md
+++ b/articles/golang/generic/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://golang.preview" target="\_blank">http://golang
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/generic/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/generic/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/golang/gin/preview-your-app.md
+++ b/articles/golang/gin/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://gin.preview" target="\_blank">http://gin.previ
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/gin/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/gin/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/golang/hugo/preview-your-app.md
+++ b/articles/golang/hugo/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://hugo.preview" target="\_blank">http://hugo.pre
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/hugo/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/hugo/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/golang/iris/preview-your-app.md
+++ b/articles/golang/iris/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://iris.preview" target="\_blank">http://iris.pre
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/iris/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/iris/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/golang/revel/preview-your-app.md
+++ b/articles/golang/revel/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://revel.preview" target="\_blank">http://revel.p
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/revel/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/golang/revel/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/adonis/preview-your-app.md
+++ b/articles/nodejs/adonis/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://adonis.preview" target="\_blank">http://adonis
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/adonis/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/adonis/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/done/preview-your-app.md
+++ b/articles/nodejs/done/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://done.preview" target="\_blank">http://done.pre
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/done/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/done/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/express/preview-your-app.md
+++ b/articles/nodejs/express/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://express.preview" target="\_blank">http://expre
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/express/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/express/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/feathers/preview-your-app.md
+++ b/articles/nodejs/feathers/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://feathers.preview" target="\_blank">http://feat
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/feathers/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/feathers/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/generic/preview-your-app.md
+++ b/articles/nodejs/generic/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://generic.preview" target="\_blank">http://gener
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/generic/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/generic/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/hapi/preview-your-app.md
+++ b/articles/nodejs/hapi/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://hapi.preview" target="\_blank">http://hapi.pre
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/hapi/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/hapi/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/koa/preview-your-app.md
+++ b/articles/nodejs/koa/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://koa.preview" target="\_blank">http://koa.previ
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/koa/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/koa/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/nodal/preview-your-app.md
+++ b/articles/nodejs/nodal/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://nodal.preview" target="\_blank">http://nodal.p
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/nodal/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/nodal/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/nodejs/sails/preview-your-app.md
+++ b/articles/nodejs/sails/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://sails.preview" target="\_blank">http://sails.p
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/sails/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/nodejs/sails/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/cakephp/preview-your-app.md
+++ b/articles/php/cakephp/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://cakephp.preview" target="\_blank">http://cakep
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/cakephp/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/cakephp/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/codeigniter/preview-your-app.md
+++ b/articles/php/codeigniter/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://codeigniter.preview" target="\_blank">http://c
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/codeigniter/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/codeigniter/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/generic/preview-your-app.md
+++ b/articles/php/generic/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://php.preview" target="\_blank">http://php.previ
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/generic/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/generic/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/laravel/preview-your-app.md
+++ b/articles/php/laravel/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://laravel.preview" target="\_blank">http://larav
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/laravel/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/laravel/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/lumen/preview-your-app.md
+++ b/articles/php/lumen/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://lumen.preview" target="\_blank">http://lumen.p
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/lumen/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/lumen/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/nette/preview-your-app.md
+++ b/articles/php/nette/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://nette.preview" target="\_blank">http://nette.p
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/nette/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/nette/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/phalcon/preview-your-app.md
+++ b/articles/php/phalcon/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://phalcon.preview" target="\_blank">http://phalc
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/phalcon/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/phalcon/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/slim/preview-your-app.md
+++ b/articles/php/slim/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://slim.preview" target="\_blank">http://slim.pre
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/slim/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/slim/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/php/symfony/preview-your-app.md
+++ b/articles/php/symfony/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://symfony.preview" target="\_blank">http://symfo
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/symfony/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/php/symfony/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/python/django/preview-your-app.md
+++ b/articles/python/django/preview-your-app.md
@@ -21,4 +21,4 @@ Visit your app at <a href="http://django.preview" target="\_blank">http://django
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/python/django/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/python/django/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/python/flask/preview-your-app.md
+++ b/articles/python/flask/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://flask.preview" target="\_blank">http://flask.p
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/python/flask/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/python/flask/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/python/generic/preview-your-app.md
+++ b/articles/python/generic/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://python.preview" target="\_blank">http://python
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/python/generic/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/python/generic/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/ruby/generic/preview-your-app.md
+++ b/articles/ruby/generic/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://ruby.preview" target="\_blank">http://ruby.pre
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/ruby/generic/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/ruby/generic/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/ruby/rails/preview-your-app.md
+++ b/articles/ruby/rails/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://rails.preview" target="\_blank">http://rails.p
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/ruby/rails/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/ruby/rails/local-evars) with `nanobox evar add dry-run KEY=VALUE`.

--- a/articles/ruby/sinatra/preview-your-app.md
+++ b/articles/ruby/sinatra/preview-your-app.md
@@ -19,4 +19,4 @@ Visit your app at <a href="http://sinatra.preview" target="\_blank">http://sinat
 
 With `dry-run` your app will continue to run until stopped (`ctrl + c`). This allows you to to preview it, watch logs, seed data, and troubleshoot.
 
-**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/ruby/sinatra/local-evars) with `nanobox add evar dry-run KEY=VALUE`.
+**HEADS UP**: You can add environment variables to dry-run the same way you do [locally](/ruby/sinatra/local-evars) with `nanobox evar add dry-run KEY=VALUE`.


### PR DESCRIPTION
The guides, in the "preview your app" section, mention running `nanobox add evar dry-run KEY=VALUE` to add dry-run environment variables, but the CLI seems to expect the command as `nanobox evar add dry-run KEY=VALUE` (`evar add` versus the guides' `add evar`)