### PR TITLE
Change to  'feathers generate app'

### DIFF
--- a/articles/nodejs/feathers/from-scratch.md
+++ b/articles/nodejs/feathers/from-scratch.md
@@ -30,7 +30,7 @@ nanobox run
 npm install -g feathers-cli
 
 # generate the feathers app; follow the prompts to create your application
-feathers generate
+feathers generate app
 
 # exit the yarn console
 exit


### PR DESCRIPTION
Changed from 'feathers generate' to 'feathers generate app'; appears to be typo (see [feathers-cli](https://github.com/feathersjs/feathers-cli))