### PR TITLE
should be explicitHost instead of host

### DIFF
--- a/articles/nodejs/sails/existing-app.md
+++ b/articles/nodejs/sails/existing-app.md
@@ -28,7 +28,7 @@ run.config:
 To allow connections from the host machine into the app's container, you'll need to configure your app to listen on all available IP's (0.0.0.0) by modifying the `config/env/development.js`:
 
 ```javascript
-host: '0.0.0.0'
+explicitHost: '0.0.0.0'
 ```
 
 #### Add local DNS


### PR DESCRIPTION
debug: The `sails.config.host` setting is deprecated in Sails 1.0.
debug: Please use `sails.config.explicitHost` instead.